### PR TITLE
Enable tracking of individual pageviews

### DIFF
--- a/lib/angulartics-hubspot.js
+++ b/lib/angulartics-hubspot.js
@@ -17,8 +17,8 @@
        */
       $analyticsProvider.registerPageTrack(function (path) {
         if (window._hsq) {
-          _hsq.push();
-          _hsq.push(['trackPageView', path]);
+          _hsq.push(['setPath', path]);
+          _hsq.push(['trackPageView']);
         }
       });
 

--- a/lib/angulartics-hubspot.js
+++ b/lib/angulartics-hubspot.js
@@ -17,8 +17,8 @@
        */
       $analyticsProvider.registerPageTrack(function (path) {
         if (window._hsq) {
-          _hsq.push(['setPath', path]);
           _hsq.push(['trackPageView']);
+          _hsq.push(['setPath', path]);
         }
       });
 


### PR DESCRIPTION
HubSpot just updated their API to make individual pageviews trackable, this pull request updates the tracking.

See this blog post: 
[https://knowledge.hubspot.com/articles/kcs_article/reports/does-hubspot-support-analytics-tracking-for-single-page-applications]